### PR TITLE
add app for starting, stopping other apps based on ip-pings

### DIFF
--- a/python_ledbox/App.py
+++ b/python_ledbox/App.py
@@ -3,43 +3,42 @@ from python_ledbox.Matrix import Matrix
 
 
 class App(ABC):
-    def __init__(self, matrix: Matrix):
-        self.__isActive = False
-        self.__isInitialised = False
-        self.matrix = matrix
+    def __init__(self):
+        self._isActive = False
+        self._isInitialised = False
 
     def start(self) -> None:
-        """Start app, may be used to start app for first time if resume() is implemented. Subclasses should call super().start() before implementing their own start method"""
+        """Start app, extra initialization step may be necessary. Subclasses should call super().start() before implementing their own start method"""
 
-        self.__isActive = True
-        self.__isInitialised = True
+        self._isActive = True
+        self._isInitialised = True
 
     def stop(self) -> None:
         """Stop app, may not kill all processes if kill() method is implemented. Subclasses should call super().stop() before implementing their own stop method."""
 
-        self.__isActive = False
+        self._isActive = False
 
-    def resume(self) -> None:
-        """Resume app, should be implemented to start app if it has already been initialiazed. Calls start() by default, should set self.isActive to True if start() is not called."""
+    # def resume(self) -> None:
+    #     """Resume app, should be implemented to start app if it has already been initialiazed. Calls start() by default, should set self.isActive to True if start() is not called."""
 
-        if not self.__isInitialised:
-            raise Exception(
-                "Cannot resume app, it has not yet been initialzed, call start() instead."
-            )
-        self.start()
+    #     if not self.__isInitialised:
+    #         raise Exception(
+    #             "Cannot resume app, it has not yet been initialzed, call start() instead."
+    #         )
+    #     self.start()
 
     def kill(self) -> None:
-        """Kill app, stopping all processes. Initialisation by calling start() may be necessary (should set self.__isInitialised and self.isActive to False ). Calls stop() by default."""
+        """Kill app, stopping all processes (should set self.__isInitialised and self.isActive to False ). Calls stop() by default."""
 
-        self.__isInitialised = False
+        self._isInitialised = False
         self.stop()
 
     def isActive(self) -> bool:
         """Returns wether app is active or not."""
 
-        return self.__isActive
+        return self._isActive
 
     def isInitialised(self) -> bool:
         """Returns wether app has been initialized or not."""
 
-        return self.__isInitialised
+        return self._isInitialised

--- a/python_ledbox/apps/ClockApp.py
+++ b/python_ledbox/apps/ClockApp.py
@@ -13,7 +13,9 @@ from python_ledbox.Matrix import Matrix
 
 class ClockApp(App):
     def __init__(self, matrix: Matrix, frame: Frame):
-        super().__init__(matrix)
+        super().__init__()
+
+        self.matrix = matrix
         self.__frame = frame
         self.__imageLoader = ImageLoader()
         self.__imageLoader.load("python_ledbox/images/numerals/")
@@ -28,9 +30,10 @@ class ClockApp(App):
         self.minute_first_digit_color: int = Color.red
         self.minute_second_digit_color: int = Color.red
 
-        self.__isInitialised = True  # no initialization necessary
+        self._isInitialised = True  # no initialization necessary
 
     def __updateTime(self, time: datetime) -> None:
+
         hour_first_digit = self.__imageLoader.get(str(time.hour // 10))
         hour_second_digit = self.__imageLoader.get(str(time.hour % 10))
         minute_first_digit = self.__imageLoader.get(str(time.minute // 10))

--- a/python_ledbox/apps/PingSwitchApp.py
+++ b/python_ledbox/apps/PingSwitchApp.py
@@ -1,0 +1,91 @@
+import platform
+import subprocess
+from threading import Thread
+from typing import List
+from datetime import datetime  # , timedelta
+import time
+
+
+from python_ledbox.App import App
+
+
+class PingSwitchApp(App):
+    def __init__(self, ipAddress: str):
+        App.__init__(self)
+        # configurables
+        self.ipAddress: str = ipAddress
+        self.startDelay: int = 60
+        self.stopDelay: int = 300
+        self.pingInterval: int = 60
+        self.killOnStop: bool = False
+        self.apps: List[App] = []
+
+        self.__appsRunning: bool = False
+        self.__online_since: int = None
+        self.__offline_since: int = None
+
+    def __ping(self, host: str):
+        """
+        Returns True if host (str) responds to a ping request.
+        Remember that a host may not respond to a ping (ICMP) request even if the host name is valid.
+        """
+
+        # Option for the number of packets as a function of
+        packets = "-n" if platform.system().lower() == "windows" else "-c"
+
+        # Building the command. Ex: "ping -c 1 google.com"
+        command = f"ping -w 1 {packets} 1 {host}".split(" ")
+
+        # supress output with stdout=DEVNULL
+        return subprocess.call(command, stdout=subprocess.DEVNULL) == 0
+
+    def __updateStatus(self, now: datetime) -> None:
+
+        pingSuccessful = self.__ping(self.ipAddress)
+        print(pingSuccessful)
+
+        # first uncessful ping
+        if self.__appsRunning and not pingSuccessful:
+            if self.__offline_since is None:
+                self.__offline_since = now
+                self.__online_since = None
+
+            seconds_offline = (now - self.__offline_since).total_seconds()
+
+            # print(seconds_offline)
+
+            # stop matrix
+            # add 1 to account for deviations in time.sleep
+            if seconds_offline + 1 > self.stopDelay:
+                self.__appsRunning = False
+                for app in self.apps:
+                    if self.killOnStop:
+                        app.kill()
+                    else:
+                        app.stop()
+
+        # first successful ping
+        elif not self.__appsRunning and pingSuccessful:
+            if self.__online_since is None:
+                self.__online_since = now
+                self.__offline_since = None
+
+            seconds_online = (now - self.__online_since).total_seconds()
+
+            # start matrix
+            if seconds_online + 1 > self.startDelay:
+                self.__appsRunning = True
+                for app in self.apps:
+                    app.start()
+
+    def __pingLoop(self):
+        while self._isActive:
+            self.__updateStatus(datetime.utcnow())
+            time.sleep(self.pingInterval)
+
+    def start(self):
+        super().start()
+        Thread(target=self.__pingLoop, daemon=True).start()
+
+    def stop(self):
+        super().stop()

--- a/tests/apps/test_ClockApp.py
+++ b/tests/apps/test_ClockApp.py
@@ -56,6 +56,8 @@ class TestClockApp(unittest.TestCase):
 
         matrix.applyChanges.assert_called_once_with(frame.getChanges())
 
+        app.stop()
+
     @patch("python_ledbox.apps.ClockApp.time")
     @patch("python_ledbox.apps.ClockApp.datetime")
     @patch("python_ledbox.apps.ClockApp.Matrix")
@@ -93,6 +95,8 @@ class TestClockApp(unittest.TestCase):
         self.assertEqual(4, len(mock_Image.applyToFrame.call_args_list))
 
         matrix.applyChanges.assert_called_once_with(frame.getChanges())
+
+        app.stop()
 
     @patch("python_ledbox.apps.ClockApp.time")
     @patch("python_ledbox.apps.ClockApp.datetime")
@@ -137,6 +141,8 @@ class TestClockApp(unittest.TestCase):
             self.assertIn(c, mock_Image.applyToFrame.call_args_list)
 
         matrix.applyChanges.assert_called_once_with(frame.getChanges())
+
+        app.stop()
 
     @patch("python_ledbox.apps.ClockApp.time")
     @patch("python_ledbox.apps.ClockApp.datetime")
@@ -184,3 +190,5 @@ class TestClockApp(unittest.TestCase):
             self.assertIn(c, mock_Image.applyToFrame.call_args_list)
 
         matrix.applyChanges.assert_called_once_with(frame.getChanges())
+
+        app.stop()

--- a/tests/apps/test_PingSwitchApp.py
+++ b/tests/apps/test_PingSwitchApp.py
@@ -1,0 +1,116 @@
+import unittest
+from unittest.mock import patch, Mock
+
+from datetime import datetime
+import time
+
+from python_ledbox.apps.PingSwitchApp import PingSwitchApp
+
+# learning from testing with threads
+# - use time.sleep for forcing thread switch
+# - stop the thread after each testcase
+#   (Possble problem that I encountered: the patched methods are not properly patched anymore and lead to errors)
+
+
+class TestPingSwitchApp(unittest.TestCase):
+    def setUp(self):
+        self.switch = PingSwitchApp("localhost")
+        self.switch.startDelay = 1
+        self.switch.stopDelay = 5
+        self.switch.apps = [Mock(), Mock()]
+
+    @patch("python_ledbox.apps.PingSwitchApp.subprocess")
+    @patch("python_ledbox.apps.PingSwitchApp.datetime")
+    @patch("python_ledbox.apps.PingSwitchApp.time")
+    def test_start_app(self, mock_time, mock_dt, mock_subprocess):
+        """Test that starting app starts apps inside after startDelay."""
+
+        mock_subprocess.call = Mock(return_value=0)
+        mock_time.sleep = Mock(side_effect=lambda x: time.sleep(0.001))
+        mock_dt.utcnow = Mock(return_value=datetime(2000, 1, 1, 0, 0))
+
+        self.switch.start()
+
+        # switch should be running but apps not active
+        self.assertTrue(self.switch.isActive())
+        self.assertFalse(self.switch.apps[0].start.called)
+
+        # update time
+        mock_dt.utcnow = Mock(return_value=datetime(2000, 1, 1, 0, 1))
+        time.sleep(0.01)
+
+        # app should be running 1 minute later
+        self.assertTrue(self.switch.apps[0].start.called)
+        self.assertTrue(self.switch.apps[1].start.called)
+
+        self.switch.stop()
+
+    # # TODO eliminate repeated code by createing extra decorated method
+    @patch("python_ledbox.apps.PingSwitchApp.subprocess")
+    @patch("python_ledbox.apps.PingSwitchApp.datetime")
+    @patch("python_ledbox.apps.PingSwitchApp.time")
+    def test_stops_app(self, mock_time, mock_dt, mock_subprocess):
+        """Test that app is stopped after ip-address becomes unreachable."""
+
+        mock_subprocess.call = Mock(return_value=0)
+
+        # forces thread to be switched
+        mock_time.sleep = Mock(side_effect=lambda x: time.sleep(0.001))
+
+        mock_dt.utcnow = Mock(return_value=datetime(2000, 1, 1, 1, 0))
+        self.switch.start()
+
+        mock_dt.utcnow = Mock(return_value=datetime(2000, 1, 1, 1, 1))
+        time.sleep(0.01)
+
+        # switch should be running and apps active
+        self.assertTrue(self.switch.isActive())
+        self.assertTrue(self.switch.apps[0].start.called)
+
+        # ip is not responding
+        mock_subprocess.call = Mock(return_value=1)
+        time.sleep(0.01)
+
+        # stop interval reached
+        mock_dt.utcnow = Mock(return_value=datetime(2000, 1, 1, 1, 6))
+        time.sleep(0.01)
+        self.assertTrue(self.switch.apps[0].stop.called)
+
+        self.switch.stop()
+
+    @patch("python_ledbox.apps.PingSwitchApp.subprocess")
+    @patch("python_ledbox.apps.PingSwitchApp.datetime")
+    @patch("python_ledbox.apps.PingSwitchApp.time")
+    def test_kills_app(self, mock_time, mock_dt, mock_subprocess):
+        """Test that app is killed after ip-address becomes unreachable."""
+
+        self.switch.killOnStop = True
+
+        mock_subprocess.call = Mock(return_value=0)
+
+        # forces thread to be switched
+        mock_time.sleep = Mock(side_effect=lambda x: time.sleep(0.001))
+
+        mock_dt.utcnow = Mock(return_value=datetime(2000, 1, 1, 1, 0))
+        self.switch.start()
+
+        mock_dt.utcnow = Mock(return_value=datetime(2000, 1, 1, 1, 1))
+        time.sleep(0.01)
+
+        # switch should be running and apps active
+        self.assertTrue(self.switch.isActive())
+        self.assertTrue(self.switch.apps[0].start.called)
+
+        # ip is not responding
+        mock_subprocess.call = Mock(return_value=1)
+        time.sleep(0.01)
+
+        # stop interval reached
+        mock_dt.utcnow = Mock(return_value=datetime(2000, 1, 1, 1, 6))
+        time.sleep(0.01)
+        self.assertTrue(self.switch.apps[0].kill.called)
+
+        self.switch.stop()
+
+    # def test_exception_invalid_ip(self):
+    #     """Test that exception is thrown if the ip is invalid."""

--- a/tests/test_App.py
+++ b/tests/test_App.py
@@ -3,17 +3,12 @@ from unittest.mock import Mock, MagicMock
 
 from python_ledbox.App import App
 
-# mock matrix object
-mockMatrix = Mock()
-
 
 class TestApp(unittest.TestCase):
     def test_initialisation_and_start(self):
         """Test that calling start for the first time causes app to be initialized and active."""
 
-        app = App(mockMatrix)
-
-        self.assertEqual(app.matrix, mockMatrix)
+        app = App()
 
         # app should not be running
         self.assertFalse(app.isInitialised())
@@ -29,34 +24,17 @@ class TestApp(unittest.TestCase):
         """Test that calling stop() methods makes app be inactive."""
 
         # initialize and start app
-        app = App(mockMatrix)
+        app = App()
         app.start()
 
         # stop app
         app.stop()
         self.assertFalse(app.isActive())
 
-    def test_resume_calls_start(self):
-        """Test that calling resume() will call start() by default."""
-
-        app = App(mockMatrix)
-
-        # mock start method to count calls
-        app.start = MagicMock(side_effect=app.start)
-
-        app.start()
-        # stop app
-        app.stop()
-
-        # resume app
-        app.resume()
-        self.assertEqual(len(app.start.call_args_list), 2)
-        self.assertTrue(app.isActive())
-
     def test_kill_calls_stop(self):
         """Test that calling kill() will call stop() by default."""
 
-        app = App(mockMatrix)
+        app = App()
         app.start()
 
         # mock stop method to count calls
@@ -69,10 +47,27 @@ class TestApp(unittest.TestCase):
         self.assertFalse(app.isInitialised())
         self.assertFalse(app.isActive())
 
-    def test_resume_before_initialize_raises_exeption(self):
-        """Test that calling resume before starting app raises an exception."""
+    # def test_resume_calls_start(self):
+    #     """Test that calling resume() will call start() by default."""
 
-        app = App(mockMatrix)
+    #     app = App(mockMatrix)
 
-        with self.assertRaises(Exception):
-            app.resume()
+    #     # mock start method to count calls
+    #     app.start = MagicMock(side_effect=app.start)
+
+    #     app.start()
+    #     # stop app
+    #     app.stop()
+
+    #     # resume app
+    #     app.resume()
+    #     self.assertEqual(len(app.start.call_args_list), 2)
+    #     self.assertTrue(app.isActive())
+
+    # def test_resume_before_initialize_raises_exeption(self):
+    #     """Test that calling resume before starting app raises an exception."""
+
+    #     app = App(mockMatrix)
+
+    #     with self.assertRaises(Exception):
+    #         app.resume()


### PR DESCRIPTION
closes #12  

- add PingSwitchApp for starting, stopping other apps by pinging certain ip-adress
 - add stop method calls to tests of ClockApp to stop threads which may cause problems (see comment in test for PingSwitchApp)
 - change "private" (__) attributes to proteced (_) to allow subclasses to access attributes in App class
 - remove resume method from App (not necessary, can differentiate in start method with isInitialized attribute)
 - remove matrix parameter from App (not all apps need matrix)